### PR TITLE
Add padding-describe-blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
     "rules": {
-        "jest-formatting/padding-test-blocks": 2
+        "jest-formatting/padding-test-blocks": 2,
+        "jest-formatting/padding-describe-blocks": 2,
     }
 }
 ```
@@ -47,6 +48,7 @@ Then configure the rules you want to use under the rules section.
 
 * [padding-test-blocks](docs/rules/padding-test-blocks.md)
 
+* [padding-describe-blocks](docs/rules/padding-describe-blocks.md)
 
 
 

--- a/docs/rules/padding-describe-blocks.md
+++ b/docs/rules/padding-describe-blocks.md
@@ -1,0 +1,32 @@
+# padding-describe-blocks
+
+## Rule Details
+
+This rule enforces single line padding around describe blocks 
+
+Examples of **incorrect** code for this rule:
+
+```js
+
+describe('foo', () => {
+  // stuff
+})
+describe('bar', ()=>{
+  // more stuff
+})
+
+```
+
+Examples of **correct** code for this rule:
+
+```js
+
+describe('foo', () => {
+  // stuff
+})
+
+describe('bar', ()=>{
+  // more stuff
+})
+
+```

--- a/lib/rules/padding-describe-blocks.js
+++ b/lib/rules/padding-describe-blocks.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Enforces single line padding around describe blocks
+ * @author Dan Green-Leipciger
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const setPaddingBetweenNodes = ({
+  context,
+  problemNode,
+  firstNode,
+  secondNode,
+  message
+}) => {
+  context.report({
+    node: problemNode,
+    message,
+    fix: function(fixer) {
+      return [
+        fixer.removeRange([
+          firstNode.end,
+          secondNode.start - secondNode.loc.start.column
+        ]),
+        fixer.insertTextAfter(firstNode, "\n\n")
+      ];
+    }
+  });
+};
+
+const getLeftSibling = node => {
+  const siblings = node.parent.body;
+  return siblings.find(s => s.end === node.start - 1);
+};
+
+const getRightSibling = node => {
+  const siblings = node.parent.body;
+  return siblings.find(s => s.start === node.end + 1);
+};
+
+const getStartLine = node => node && node.loc.start.line;
+const getEndLine = node => node && node.loc.start.line;
+
+const beforeMessage =
+  "You need a newline before a describe block when it comes after another expression";
+const afterMessage =
+  "You need a newline after a describe block when it comes before another expression";
+
+const isNotDescribe = node => node.expression.callee.name !== "describe";
+
+const shouldFixGap = (bottomNode, topNode) =>
+  getStartLine(topNode) - getEndLine(bottomNode) !== 2;
+
+module.exports = {
+  meta: {
+    docs: {
+      description: "Enforces single line padding around describe blocks",
+      category: "Fill me in",
+      recommended: false
+    },
+    fixable: "whitespace", // or "code" or "whitespace"
+    schema: [
+      // fill in your schema
+    ]
+  },
+  beforeMessage,
+  afterMessage,
+  create(context) {
+    return {
+      ExpressionStatement(node) {
+        if (isNotDescribe(node)) {
+          return;
+        }
+        const leftSibling = getLeftSibling(node);
+        const rightSibling = getRightSibling(node);
+
+        if (
+          leftSibling &&
+          isNotDescribe(leftSibling) &&
+          shouldFixGap(leftSibling, node)
+        ) {
+          setPaddingBetweenNodes({
+            context,
+            problemNode: node,
+            firstNode: leftSibling,
+            secondNode: node,
+            message: beforeMessage
+          });
+        }
+
+        if (rightSibling && shouldFixGap(node, rightSibling)) {
+          setPaddingBetweenNodes({
+            context,
+            problemNode: node,
+            firstNode: node,
+            secondNode: rightSibling,
+            message: afterMessage
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/padding-describe-blocks.spec.js
+++ b/tests/lib/rules/padding-describe-blocks.spec.js
@@ -1,0 +1,116 @@
+/**
+ * @fileoverview Enforces single line padding around describe blocks
+ * @author Dan Green-Leipciger
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/padding-describe-blocks");
+const RuleTester = require("eslint").RuleTester;
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6
+  }
+});
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const validTopLevel = `
+describe('foo',()=>{});
+
+foo();
+bar();
+
+describe('bar',()=>{});
+
+describe('baz',()=>{});
+
+baz();
+`;
+
+const invalidTopLevel = `
+describe('foo',()=>{});
+foo();
+bar();
+describe('bar',()=>{});
+describe('baz',()=>{});
+baz();
+`;
+
+const validBlockLevel = `{
+describe('foo',()=>{});
+
+foo();
+bar();
+
+describe('bar',()=>{});
+
+describe('baz',()=>{});
+
+baz();
+}`;
+
+const invalidBlockLevel = `{
+describe('foo',()=>{});
+foo();
+bar();
+describe('bar',()=>{});
+describe('baz',()=>{});
+baz();
+}`;
+
+const ruleTester = new RuleTester();
+ruleTester.run("padding-describe-blocks", rule, {
+  valid: [validTopLevel, validBlockLevel],
+  invalid: [
+    {
+      code: invalidTopLevel,
+      output: validTopLevel,
+      errors: [
+        {
+          message: rule.afterMessage,
+          type: "ExpressionStatement"
+        },
+        {
+          message: rule.beforeMessage,
+          type: "ExpressionStatement"
+        },
+        {
+          message: rule.afterMessage,
+          type: "ExpressionStatement"
+        },
+        {
+          message: rule.afterMessage,
+          type: "ExpressionStatement"
+        }
+      ]
+    },
+    {
+      code: invalidBlockLevel,
+      output: validBlockLevel,
+      errors: [
+        {
+          message: rule.afterMessage,
+          type: "ExpressionStatement"
+        },
+        {
+          message: rule.beforeMessage,
+          type: "ExpressionStatement"
+        },
+        {
+          message: rule.afterMessage,
+          type: "ExpressionStatement"
+        },
+        {
+          message: rule.afterMessage,
+          type: "ExpressionStatement"
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This adds a rule which enforces a new line between a describe an all other expressions.

Issues addressed:
- https://github.com/dangreenisrael/eslint-plugin-jest-formatting/issues/1
- https://github.com/jest-community/eslint-plugin-jest/issues/17