### PR TITLE
Release v0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jest-formatting",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "description": "Formatting rules for test written with jest",
   "keywords": [
     "eslint",


### PR DESCRIPTION
This is a bug fix that prevents a potential runtime error on non-functions that are immediately before or after a describe block