### PR TITLE
v0.0.5 Be more defensive on checking describe blocks

### DIFF
--- a/lib/rules/padding-describe-blocks.js
+++ b/lib/rules/padding-describe-blocks.js
@@ -14,7 +14,9 @@ const beforeMessage =
 const afterMessage =
   "You need a newline after a describe block when it comes before another expression";
 const isDescribe = node =>
-  node.expression && node.expression.callee.name === "describe";
+  node.expression &&
+  node.expression.callee &&
+  node.expression.callee.name === "describe";
 
 module.exports = {
   meta: {
@@ -31,9 +33,14 @@ module.exports = {
   beforeMessage,
   afterMessage,
   create(context) {
+    const filePath = context && context.getFilename();
+    const isTest =
+      filePath.includes("test") ||
+      filePath.includes("spec") ||
+      filePath.includes("<input>");
     return {
       ExpressionStatement(node) {
-        if (!isDescribe(node)) {
+        if (!isTest || !isDescribe(node)) {
           return;
         }
         padBothSides(context, node, isDescribe, beforeMessage, afterMessage);


### PR DESCRIPTION
There was a potential for errors where these node.expression.callee was not defined.