### PR TITLE
Stop using require index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-[![CircleCI](https://circleci.com/gh/dangreenisrael/eslint-plugin-jest-formatting/tree/master.svg?style=svg)](https://circleci.com/gh/dangreenisrael/eslint-plugin-jest-formatting/tree/master)
+[![CircleCI](https://circleci.com/gh/dangreenisrael/eslint-plugin-jest-formatting/tree/master.svg?style=svg)](https://circleci.com/gh/dangreenisrael/eslint-plugin-jest-formatting/tree/master) [![star this repo](http://githubbadges.com/star.svg?user=dangreenisrael&repo=eslint-plugin-jest-formatting&style=flat)](https://github.com/dangreenisrael/eslint-plugin-jest-formatting/stargazers)
 
-# This is not stable yet, API will likely change before v1.0.0
 
 # eslint-plugin-jest-formatting
 
 Formatting rules for tests written in jest
+
+Like this plugin? [Say thanks with a ⭐️](https://github.com/dangreenisrael/eslint-plugin-jest-formatting/stargazers)
+
+
 
 ## Installation
 
@@ -55,3 +58,5 @@ Then configure the rules you want to use under the rules section.
 
 
 
+<!-- Github button script -->
+<script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var requireIndex = require("requireindex");
+const paddingBeforeDescribeBlocks = require('./rules/padding-before-describe-blocks')
+const paddingBeforeTestBlocks = require('./rules/padding-before-test-blocks')
 
 //------------------------------------------------------------------------------
 // Plugin Definition
@@ -16,7 +17,9 @@ var requireIndex = require("requireindex");
 
 
 // import all rules in lib/rules
-module.exports.rules = requireIndex(__dirname + "/rules");
 
-
+module.exports.rules = {
+    'padding-before-describe-blocks':paddingBeforeDescribeBlocks,
+    'padding-before-test-blocks':paddingBeforeTestBlocks,
+}
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jest-formatting",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Formatting rules for test written with jest",
   "keywords": [
     "eslint",
@@ -17,9 +17,6 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest"
-  },
-  "dependencies": {
-    "requireindex": "~1.2.0"
   },
   "devDependencies": {
     "eslint": "5.16.0",

--- a/tests/lib/rules/padding-before-describe-blocks.spec.js
+++ b/tests/lib/rules/padding-before-describe-blocks.spec.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/padding-before-describe-blocks");
+const rule = require("../../../lib").rules['padding-before-describe-blocks'];
 const RuleTester = require("eslint").RuleTester;
 
 RuleTester.setDefaultConfig({

--- a/tests/lib/rules/padding-before-test-blocks.spec.js
+++ b/tests/lib/rules/padding-before-test-blocks.spec.js
@@ -8,7 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/padding-before-test-blocks");
+const rule = require("../../../lib").rules["padding-before-test-blocks"];
 const RuleTester = require("eslint").RuleTester;
 
 RuleTester.setDefaultConfig({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3139,11 +3139,6 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
-requireindex@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
-  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
-
 resolve-cwd@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-2.0.0.tgz#00a9f7387556e27038eae232caa372a6a59b665a"


### PR DESCRIPTION
- Explicitly require and export rules instead of using requireIndex
- drop `requireindex` from dependencies
- Drop the stability warning and add a start button