### PR TITLE
Proof of concept for general Jest padding rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules
-lib
+/node_modules
+/lib

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jest-formatting",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Formatting rules for jest tests",
   "keywords": [
     "eslint",
@@ -23,6 +23,9 @@
     "build": "tsc",
     "test": "yarn build && jest"
   },
+  "peerDependencies": {
+    "eslint": "5.x"
+  },
   "devDependencies": {
     "@types/eslint": "4.16.6",
     "@types/jest": "24.0.11",
@@ -33,7 +36,7 @@
     "eslint-config-prettier": "5.0.0",
     "eslint-plugin-import": "2.14.0",
     "eslint-plugin-jest": "22.7.0",
-    "eslint-plugin-jest-formatting": "^0.0.10",
+    "eslint-plugin-jest-formatting": "file:.",
     "eslint-plugin-prettier": "3.1.0",
     "jest": "24.8.0",
     "prettier": "1.18.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
 import padding from './rules/padding';
 import paddingBeforeDescribeBlocks from './rules/padding-before-describe-blocks';
 import paddingBeforeTestBlocks from './rules/padding-before-test-blocks';
+import paddingBeforeExpectStatements from "./rules/padding-before-expect-statements";
 
 //------------------------------------------------------------------------------
 // Plugin Definition
@@ -17,4 +18,5 @@ export const rules = {
   padding,
   'padding-before-describe-blocks': paddingBeforeDescribeBlocks,
   'padding-before-test-blocks': paddingBeforeTestBlocks,
+  'padding-before-expect-statements': paddingBeforeExpectStatements,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
  * @author Dan
  */
 
+import padding from './rules/padding';
 import paddingBeforeDescribeBlocks from './rules/padding-before-describe-blocks';
 import paddingBeforeTestBlocks from './rules/padding-before-test-blocks';
 
@@ -13,6 +14,7 @@ import paddingBeforeTestBlocks from './rules/padding-before-test-blocks';
 // import all rules in lib/rules
 
 export const rules = {
+  padding,
   'padding-before-describe-blocks': paddingBeforeDescribeBlocks,
   'padding-before-test-blocks': paddingBeforeTestBlocks,
 };

--- a/src/rules/padding-before-describe-blocks.ts
+++ b/src/rules/padding-before-describe-blocks.ts
@@ -1,48 +1,14 @@
-/**
- * @fileoverview Enforces single line padding around describe blocks
- * @author Dan Green-Leipciger
- */
-'use strict';
-
-import { padBefore } from '../utils';
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
-
-const beforeMessage =
-  'You need a newline or comment before a describe block when it comes after another expression';
-
-const isDescribe = node =>
-  node.expression &&
-  node.expression.callee &&
-  node.expression.callee.name === 'describe';
+import padding from './padding';
 
 export default {
-  meta: {
-    docs: {
-      description: 'Enforces at least a line of padding before describe blocks',
-      category: 'Fill me in',
-      recommended: false,
-    },
-    fixable: 'whitespace', // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ],
-  },
-  beforeMessage,
+  ...padding,
   create(context) {
-    const filePath = context && context.getFilename();
-    const isTest =
-      filePath.includes('test') ||
-      filePath.includes('spec') ||
-      filePath.includes('<input>');
-    return {
-      ExpressionStatement(node) {
-        if (!isTest || !isDescribe(node)) {
-          return;
-        }
-        padBefore({ context, node, beforeMessage });
-      },
-    };
+    const ctx = Object.create(context, {
+      options: {
+        value: [{blankLine: 'always', prev: '*', next: 'describe'}]
+      }
+    });
+
+    return padding.create(ctx);
   },
 };

--- a/src/rules/padding-before-expect-statements.ts
+++ b/src/rules/padding-before-expect-statements.ts
@@ -1,0 +1,17 @@
+import padding from './padding';
+
+export default {
+  ...padding,
+  create(context) {
+    const ctx = Object.create(context, {
+      options: {
+        value: [
+          {blankLine: 'always', prev: '*', next: 'expect'},
+          {blankLine: 'any', prev: 'expect', next: 'expect'}
+        ]
+      }
+    });
+
+    return padding.create(ctx);
+  },
+};

--- a/src/rules/padding-before-test-blocks.ts
+++ b/src/rules/padding-before-test-blocks.ts
@@ -1,49 +1,14 @@
-/**
- * @fileoverview Enforces a single like of padding between test blocks with a describe
- * @author Dan
- */
-'use strict';
-
-import { padBefore } from '../utils';
-//------------------------------------------------------------------------------
-// Rule Definition
-//------------------------------------------------------------------------------
-
-const beforeMessage =
-  'You need a newline or comment before an `it` or `test` block when it comes after another expression';
-
-const expressionName = node =>
-  node.expression && node.expression.callee && node.expression.callee.name;
-const isTestBlock = node =>
-  expressionName(node) === 'test' || expressionName(node) === 'it';
+import padding from './padding';
 
 export default {
-  meta: {
-    docs: {
-      description:
-        'Enforces at least a line of padding before test blocks within a describe',
-      category: 'Formatting',
-      recommended: true,
-    },
-    fixable: 'whitespace', // or "code" or "whitespace"
-    schema: [
-      // fill in your schema
-    ],
-  },
-  beforeMessage,
+  ...padding,
   create(context) {
-    const filePath = context && context.getFilename();
-    const isTestFile =
-      filePath.includes('test') ||
-      filePath.includes('spec') ||
-      filePath.includes('<input>');
-    return {
-      ExpressionStatement(node) {
-        if (!isTestFile || !isTestBlock(node)) {
-          return;
-        }
-        padBefore({ context, node, beforeMessage });
-      },
-    };
+    const ctx = Object.create(context, {
+      options: {
+        value: [{blankLine: 'always', prev: '*', next: 'test'}]
+      }
+    });
+
+    return padding.create(ctx);
   },
 };

--- a/src/rules/padding-before-test-blocks.ts
+++ b/src/rules/padding-before-test-blocks.ts
@@ -5,7 +5,10 @@ export default {
   create(context) {
     const ctx = Object.create(context, {
       options: {
-        value: [{blankLine: 'always', prev: '*', next: 'test'}]
+        value: [
+          {blankLine: 'always', prev: '*', next: 'test'},
+          {blankLine: 'always', prev: '*', next: 'it'},
+        ]
       }
     });
 

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -1,7 +1,6 @@
 /**
  * @fileoverview Rule to require or disallow newlines between jest functions,
  *   based on eslint/padding-line-between-statements by Toru Nagashima
- * @author Ben Kimpel
  */
 
 //------------------------------------------------------------------------------

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -14,9 +14,6 @@ const astUtils = require('eslint/lib/util/ast-utils');
 // Helpers
 //------------------------------------------------------------------------------
 
-// TODO: Check how this behaves when run alongside padding-line-between-statements
-// TODO: Allow customizing pattern to identify test files (can jest provide it? can we detect it with import?)
-
 const LT = `[${Array.from(astUtils.LINEBREAKS).join('')}]`;
 const PADDING_LINE_SEQUENCE = new RegExp(
   String.raw`^(\s*?${LT})\s*${LT}(\s*;?)$`,

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -1,0 +1,438 @@
+/**
+ * @fileoverview Rule to require or disallow newlines between jest functions,
+ *   based on eslint/padding-line-between-statements by Toru Nagashima
+ * @author Ben Kimpel
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require('eslint/lib/util/ast-utils');
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+// TODO: Check how this behaves when run alongside padding-line-between-statements
+// TODO: Allow customizing pattern to identify test files (can jest provide it? can we detect it with import?)
+
+const LT = `[${Array.from(astUtils.LINEBREAKS).join('')}]`;
+const PADDING_LINE_SEQUENCE = new RegExp(
+  String.raw`^(\s*?${LT})\s*${LT}(\s*;?)$`,
+  'u',
+);
+
+/**
+ * Creates tester which check if an expression node has a certain name
+ *
+ * @param {string} name The Jest function name to test.
+ * @returns {Object} the created tester.
+ * @private
+ */
+function newJestTokenTester(name) {
+  return {
+    test: (node, sourceCode) => {
+      const token = sourceCode.getFirstToken(node);
+
+      return (
+        node.type === 'ExpressionStatement' &&
+        token.type === 'Identifier' &&
+        token.value === name
+      );
+    },
+  };
+}
+
+/**
+ * Gets the actual last token.
+ *
+ * If a semicolon is semicolon-less style's semicolon, this ignores it.
+ * For example:
+ *
+ *     foo()
+ *     ;[1, 2, 3].forEach(bar)
+ *
+ * @param {SourceCode} sourceCode The source code to get tokens.
+ * @param {ASTNode} node The node to get.
+ * @returns {Token} The actual last token.
+ * @private
+ */
+function getActualLastToken(sourceCode, node) {
+  const semiToken = sourceCode.getLastToken(node);
+  const prevToken = sourceCode.getTokenBefore(semiToken);
+  const nextToken = sourceCode.getTokenAfter(semiToken);
+  const isSemicolonLessStyle = Boolean(
+    prevToken &&
+      nextToken &&
+      prevToken.range[0] >= node.range[0] &&
+      astUtils.isSemicolonToken(semiToken) &&
+      semiToken.loc.start.line !== prevToken.loc.end.line &&
+      semiToken.loc.end.line === nextToken.loc.start.line,
+  );
+
+  return isSemicolonLessStyle ? prevToken : semiToken;
+}
+
+/**
+ * This returns the concatenation of the first 2 captured strings.
+ * @param {string} _ Unused. Whole matched string.
+ * @param {string} trailingSpaces The trailing spaces of the first line.
+ * @param {string} indentSpaces The indentation spaces of the last line.
+ * @returns {string} The concatenation of trailingSpaces and indentSpaces.
+ * @private
+ */
+function replacerToRemovePaddingLines(_, trailingSpaces, indentSpaces) {
+  return trailingSpaces + indentSpaces;
+}
+
+/**
+ * Check and report statements for `any` configuration.
+ * It does nothing.
+ *
+ * @returns {void}
+ * @private
+ */
+function verifyForAny() {}
+
+/**
+ * Check and report statements for `never` configuration.
+ * This autofix removes blank lines between the given 2 statements.
+ * However, if comments exist between 2 blank lines, it does not remove those
+ * blank lines automatically.
+ *
+ * @param {RuleContext} context The rule context to report.
+ * @param {ASTNode} _ Unused. The previous node to check.
+ * @param {ASTNode} nextNode The next node to check.
+ * @param {Array<Token[]>} paddingLines The array of token pairs that blank
+ * lines exist between the pair.
+ * @returns {void}
+ * @private
+ */
+function verifyForNever(context, _, nextNode, paddingLines) {
+  if (paddingLines.length === 0) {
+    return;
+  }
+
+  context.report({
+    node: nextNode,
+    message: 'Unexpected blank line before this statement.',
+    fix(fixer) {
+      if (paddingLines.length >= 2) {
+        return null;
+      }
+
+      const prevToken = paddingLines[0][0];
+      const nextToken = paddingLines[0][1];
+      const start = prevToken.range[1];
+      const end = nextToken.range[0];
+      const text = context
+        .getSourceCode()
+        .text.slice(start, end)
+        .replace(PADDING_LINE_SEQUENCE, replacerToRemovePaddingLines);
+
+      return fixer.replaceTextRange([start, end], text);
+    },
+  });
+}
+
+/**
+ * Check and report statements for `always` configuration.
+ * This autofix inserts a blank line between the given 2 statements.
+ * If the `prevNode` has trailing comments, it inserts a blank line after the
+ * trailing comments.
+ *
+ * @param {RuleContext} context The rule context to report.
+ * @param {ASTNode} prevNode The previous node to check.
+ * @param {ASTNode} nextNode The next node to check.
+ * @param {Array<Token[]>} paddingLines The array of token pairs that blank
+ * lines exist between the pair.
+ * @returns {void}
+ * @private
+ */
+function verifyForAlways(context, prevNode, nextNode, paddingLines) {
+  if (paddingLines.length > 0) {
+    return;
+  }
+
+  context.report({
+    node: nextNode,
+    message: 'Expected blank line before this statement.',
+    fix(fixer) {
+      const sourceCode = context.getSourceCode();
+      let prevToken = getActualLastToken(sourceCode, prevNode);
+      const nextToken =
+        sourceCode.getFirstTokenBetween(prevToken, nextNode, {
+          includeComments: true,
+
+          /**
+           * Skip the trailing comments of the previous node.
+           * This inserts a blank line after the last trailing comment.
+           *
+           * For example:
+           *
+           *     foo(); // trailing comment.
+           *     // comment.
+           *     bar();
+           *
+           * Get fixed to:
+           *
+           *     foo(); // trailing comment.
+           *
+           *     // comment.
+           *     bar();
+           *
+           * @param {Token} token The token to check.
+           * @returns {boolean} `true` if the token is not a trailing comment.
+           * @private
+           */
+          filter(token) {
+            if (astUtils.isTokenOnSameLine(prevToken, token)) {
+              prevToken = token;
+              return false;
+            }
+            return true;
+          },
+        }) || nextNode;
+      const insertText = astUtils.isTokenOnSameLine(prevToken, nextToken)
+        ? '\n\n'
+        : '\n';
+
+      return fixer.insertTextAfter(prevToken, insertText);
+    },
+  });
+}
+
+/**
+ * Types of blank lines.
+ * `any`, `never`, and `always` are defined.
+ * Those have `verify` method to check and report statements.
+ * @private
+ */
+const PaddingTypes = {
+  any: { verify: verifyForAny },
+  never: { verify: verifyForNever },
+  always: { verify: verifyForAlways },
+};
+
+/**
+ * Types of statements.
+ * Those have `test` method to check it matches to the given statement.
+ * @private
+ */
+const StatementTypes = {
+  '*': { test: () => true },
+  afterAll: newJestTokenTester('afterAll'),
+  afterEach: newJestTokenTester('afterEach'),
+  beforeAll: newJestTokenTester('beforeAll'),
+  beforeEach: newJestTokenTester('beforeEach'),
+  describe: newJestTokenTester('describe'),
+  expect: newJestTokenTester('expect'),
+  it: newJestTokenTester('it'),
+  test: newJestTokenTester('test'),
+};
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+export default {
+  meta: {
+    type: 'layout',
+    docs: {
+      description: 'require or disallow padding lines between jest statements',
+      category: 'Stylistic Issues',
+      recommended: false,
+      // TODO: Link to page on GH wiki
+      // url: 'https://eslint.org/docs/rules/padding-line-between-statements',
+    },
+    fixable: 'whitespace',
+    schema: {
+      definitions: {
+        paddingType: {
+          enum: Object.keys(PaddingTypes),
+        },
+        statementType: {
+          anyOf: [
+            { enum: Object.keys(StatementTypes) },
+            {
+              type: 'array',
+              items: { enum: Object.keys(StatementTypes) },
+              minItems: 1,
+              uniqueItems: true,
+              additionalItems: false,
+            },
+          ],
+        },
+      },
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          blankLine: { $ref: '#/definitions/paddingType' },
+          prev: { $ref: '#/definitions/statementType' },
+          next: { $ref: '#/definitions/statementType' },
+        },
+        additionalProperties: false,
+        required: ['blankLine', 'prev', 'next'],
+      },
+      additionalItems: false,
+    },
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    const configureList = context.options || [];
+    let scopeInfo = null;
+
+    /**
+     * Processes to enter to new scope.
+     * This manages the current previous statement.
+     * @returns {void}
+     * @private
+     */
+    function enterScope() {
+      scopeInfo = {
+        upper: scopeInfo,
+        prevNode: null,
+      };
+    }
+
+    /**
+     * Processes to exit from the current scope.
+     * @returns {void}
+     * @private
+     */
+    function exitScope() {
+      scopeInfo = scopeInfo.upper;
+    }
+
+    /**
+     * Checks whether the given node matches the given type.
+     *
+     * @param {ASTNode} node The statement node to check.
+     * @param {string|string[]} type The statement type to check.
+     * @returns {boolean} `true` if the statement node matched the type.
+     * @private
+     */
+    function match(node, type) {
+      let innerStatementNode = node;
+
+      while (innerStatementNode.type === 'LabeledStatement') {
+        innerStatementNode = innerStatementNode.body;
+      }
+
+      if (Array.isArray(type)) {
+        return type.some(match.bind(null, innerStatementNode));
+      }
+
+      return StatementTypes[type].test(innerStatementNode, sourceCode);
+    }
+
+    /**
+     * Finds the last matched configure from configureList.
+     *
+     * @param {ASTNode} prevNode The previous statement to match.
+     * @param {ASTNode} nextNode The current statement to match.
+     * @returns {Object} The tester of the last matched configure.
+     * @private
+     */
+    function getPaddingType(prevNode, nextNode) {
+      for (let i = configureList.length - 1; i >= 0; --i) {
+        const configure = configureList[i];
+        const matched =
+          match(prevNode, configure.prev) && match(nextNode, configure.next);
+
+        if (matched) {
+          return PaddingTypes[configure.blankLine];
+        }
+      }
+      return PaddingTypes.any;
+    }
+
+    /**
+     * Gets padding line sequences between the given 2 statements.
+     * Comments are separators of the padding line sequences.
+     *
+     * @param {ASTNode} prevNode The previous statement to count.
+     * @param {ASTNode} nextNode The current statement to count.
+     * @returns {Array<Token[]>} The array of token pairs.
+     * @private
+     */
+    function getPaddingLineSequences(prevNode, nextNode) {
+      const pairs = [];
+      let prevToken = getActualLastToken(sourceCode, prevNode);
+
+      if (nextNode.loc.start.line - prevToken.loc.end.line >= 2) {
+        do {
+          const token = sourceCode.getTokenAfter(prevToken, {
+            includeComments: true,
+          });
+
+          if (token.loc.start.line - prevToken.loc.end.line >= 2) {
+            pairs.push([prevToken, token]);
+          }
+
+          prevToken = token;
+        } while (prevToken.range[0] < nextNode.range[0]);
+      }
+
+      return pairs;
+    }
+
+    /**
+     * Verify padding lines between the given node and the previous node.
+     *
+     * @param {ASTNode} node The node to verify.
+     * @returns {void}
+     * @private
+     */
+    function verify(node) {
+      const parentType = node.parent.type;
+      const validParent =
+        astUtils.STATEMENT_LIST_PARENTS.has(parentType) ||
+        parentType === 'SwitchStatement';
+
+      if (!validParent) {
+        return;
+      }
+
+      // Save this node as the current previous statement.
+      const { prevNode } = scopeInfo;
+
+      // Verify.
+      if (prevNode) {
+        const type = getPaddingType(prevNode, node);
+        const paddingLines = getPaddingLineSequences(prevNode, node);
+
+        type.verify(context, prevNode, node, paddingLines);
+      }
+
+      scopeInfo.prevNode = node;
+    }
+
+    /**
+     * Verify padding lines between the given node and the previous node.
+     * Then process to enter to new scope.
+     *
+     * @param {ASTNode} node The node to verify.
+     * @returns {void}
+     * @private
+     */
+    function verifyThenEnterScope(node) {
+      verify(node);
+      enterScope();
+    }
+
+    return {
+      Program: enterScope,
+      BlockStatement: enterScope,
+      SwitchStatement: enterScope,
+      'Program:exit': exitScope,
+      'BlockStatement:exit': exitScope,
+      'SwitchStatement:exit': exitScope,
+      ':statement': verify,
+      SwitchCase: verifyThenEnterScope,
+      'SwitchCase:exit': exitScope,
+    };
+  },
+};

--- a/tests/lib/rules/padding-before-describe-blocks.spec.js
+++ b/tests/lib/rules/padding-before-describe-blocks.spec.js
@@ -102,25 +102,39 @@ ruleTester.run('padding-describe-blocks', rule, {
       code: invalid,
       errors: [
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 11,
+          column: 1
         },
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 14,
+          column: 3
         },
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 17,
+          column: 1
         },
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 21,
+          column: 5
         },
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 24,
+          column: 4
         },
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 25,
+          column: 1
         },
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+          line: 26,
+          column: 1
         },
       ]
     },

--- a/tests/lib/rules/padding-before-describe-blocks.spec.js
+++ b/tests/lib/rules/padding-before-describe-blocks.spec.js
@@ -44,10 +44,19 @@ describe('someObject', () => {
   describe('some condition', () => {
     const anotherThing = 500;
 
-    describe('yet another condition', () => {
+    describe('yet another condition', () => { // A comment over here!
     });
   });
 });
+
+describe('weird', () => {});
+
+describe.skip('skip me', () => {});
+
+describe
+  .skip('skip me too', () => {
+    // stuff
+  });
 `;
 
 const invalid = `
@@ -70,10 +79,15 @@ describe('someObject', () => {
   // Another comment
   describe('some condition', () => {
     const anotherThing = 500;
-    describe('yet another condition', () => {
+    describe('yet another condition', () => { // A comment over here!
     });
   });
-});
+});describe('weird', () => {});
+describe.skip('skip me', () => {});
+describe
+  .skip('skip me too', () => {
+    // stuff
+  });
 `;
 
 ruleTester.run('padding-describe-blocks', rule, {
@@ -81,7 +95,7 @@ ruleTester.run('padding-describe-blocks', rule, {
   invalid: [
     {
       code: invalid,
-      errors: 4,
+      errors: 7,
       output: valid,
     },
     {
@@ -98,7 +112,16 @@ ruleTester.run('padding-describe-blocks', rule, {
         },
         {
           message: 'Expected blank line before this statement.'
-        }
+        },
+        {
+          message: 'Expected blank line before this statement.'
+        },
+        {
+          message: 'Expected blank line before this statement.'
+        },
+        {
+          message: 'Expected blank line before this statement.'
+        },
       ]
     },
   ]

--- a/tests/lib/rules/padding-before-describe-blocks.spec.js
+++ b/tests/lib/rules/padding-before-describe-blocks.spec.js
@@ -10,98 +10,96 @@
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib').rules['padding-before-describe-blocks'];
 
-RuleTester.setDefaultConfig({
+const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,
   },
 });
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-const validTopLevel = `
+const valid = `
 foo();
 bar();
-const thing="ok";
 
-describe('bar',()=>{
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
 
+// A comment before describe
+describe('someText', () => {
+  describe('some condition', () => {
+  });
+
+  describe('some other condition', () => {
+  });
 });
 
-describe('baz',()=>{
+describe('someObject', () => {
+  // Another comment
+  describe('some condition', () => {
+    const anotherThing = 500;
 
+    describe('yet another condition', () => {
+    });
+  });
 });
 `;
 
-const invalidTopLevel = `
+const invalid = `
 foo();
 bar();
-const thing="ok";
-describe('bar',()=>{
 
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+// A comment before describe
+describe('someText', () => {
+  describe('some condition', () => {
+  });
+  describe('some other condition', () => {
+  });
 });
-describe('baz',()=>{
-
+describe('someObject', () => {
+  // Another comment
+  describe('some condition', () => {
+    const anotherThing = 500;
+    describe('yet another condition', () => {
+    });
+  });
 });
 `;
 
-const validBlockLevel = `{
-  foo();
-  bar();
-
-  describe('bar',()=>{
-
-  });
-
-  describe('baz',()=>{
-
-  });
-}`;
-
-const invalidBlockLevel = `{
-  foo();
-  bar();
-  describe('bar',()=>{
-
-  });
-  describe('baz',()=>{
-
-  });
-}`;
-
-const ruleTester = new RuleTester();
 ruleTester.run('padding-describe-blocks', rule, {
-  valid: [validTopLevel, validBlockLevel],
+  valid: [valid],
   invalid: [
     {
-      code: invalidTopLevel,
-      output: validTopLevel,
-      errors: [
-        {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
-        },
-
-        {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
-        },
-      ],
+      code: invalid,
+      errors: 4,
+      output: valid,
     },
     {
-      code: invalidBlockLevel,
-      output: validBlockLevel,
+      code: invalid,
       errors: [
         {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
+          message: 'Expected blank line before this statement.'
         },
-
         {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
+          message: 'Expected blank line before this statement.'
         },
-      ],
+        {
+          message: 'Expected blank line before this statement.'
+        },
+        {
+          message: 'Expected blank line before this statement.'
+        }
+      ]
     },
-  ],
+  ]
 });

--- a/tests/lib/rules/padding-before-expect-statements.spec.js
+++ b/tests/lib/rules/padding-before-expect-statements.spec.js
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Enforces single line padding before expect statements
+ * @author Ben Kimpel
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib').rules['padding-before-expect-statements'];
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const valid = `
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  const abc = 123;
+
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+});
+
+test('thing one', () => {
+  const abc = 123;
+
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+`;
+
+const invalid = `
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  const abc = 123;
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+});
+
+test('thing one', () => {
+  const abc = 123;
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+`;
+
+ruleTester.run('padding-describe-blocks', rule, {
+  valid: [valid],
+  invalid: [
+    {
+      code: invalid,
+      errors: 4,
+      output: valid,
+    },
+    {
+      code: invalid,
+      errors: [
+        {
+          message: 'Expected blank line before this statement.',
+          line: 13,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 19,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 22,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 30,
+          column: 7
+        },
+      ]
+    },
+  ]
+});

--- a/tests/lib/rules/padding-before-test-blocks.spec.js
+++ b/tests/lib/rules/padding-before-test-blocks.spec.js
@@ -70,6 +70,7 @@ const validPaddedWithComments = `
 test('foo', ()=>{
 
 })
+
 /*
 Some comment
 */
@@ -88,12 +89,10 @@ ruleTester.run('padding-between-test-blocks', rule, {
       output: validIts,
       errors: [
         {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
+          message: 'Expected blank line before this statement.',
         },
         {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
+          message: 'Expected blank line before this statement.',
         },
       ],
     },
@@ -102,8 +101,7 @@ ruleTester.run('padding-between-test-blocks', rule, {
       output: validTests,
       errors: [
         {
-          message: rule.beforeMessage,
-          type: 'ExpressionStatement',
+          message: 'Expected blank line before this statement.'
         },
       ],
     },

--- a/tests/lib/rules/padding-before-test-blocks.spec.js
+++ b/tests/lib/rules/padding-before-test-blocks.spec.js
@@ -9,7 +9,7 @@
 const { RuleTester } = require('eslint');
 const rule = require('../../../lib').rules['padding-before-test-blocks'];
 
-RuleTester.setDefaultConfig({
+const ruleTester = new RuleTester({
   parserOptions: {
     ecmaVersion: 6,
   },
@@ -19,89 +19,111 @@ RuleTester.setDefaultConfig({
 // Tests
 //------------------------------------------------------------------------------
 
-const invalidIts = `
-const foo = 'bar';
-const bar = 'baz';
-it('foo', ()=>{
-
-})
-it('bar', ()=>{
-
-})
-`;
-
-const validIts = `
+const valid = `
 const foo = 'bar';
 const bar = 'baz';
 
-it('foo', ()=>{
-
-})
-
-it('bar', ()=>{
-
-})
-`;
-
-const invalidTests = `
-describe('foo', ()=>{
-  test('foo', ()=>{
-
-  })
-  test('bar', ()=>{
-
-  })
+it('foo', () => {
+  // stuff
 });
-`;
 
-const validTests = `
-describe('foo', ()=>{
-  test('foo', ()=>{
-
-  })
-
-  test('bar', ()=>{
-
-  })
+it('bar', () => {
+  // stuff
 });
+
+test('foo foo', () => {});
+
+test('bar bar', () => {});
+
+// Nesting
+describe('other bar', () => {
+  const thing = 123;
+
+  test('is another bar w/ test', () => {
+  });
+
+  // With a comment
+  it('is another bar w/ it', () => {
+  });
+
+  test.skip('skipping', () => {}); // Another comment
+
+  it.skip('skipping too', () => {});
+});
+
+test('weird', () => {});
+
+test
+  .skip('skippy skip', () => {});
 `;
 
-const validPaddedWithComments = `
-test('foo', ()=>{
+const invalid = `
+const foo = 'bar';
+const bar = 'baz';
+it('foo', () => {
+  // stuff
+});
+it('bar', () => {
+  // stuff
+});
+test('foo foo', () => {});
+test('bar bar', () => {});
 
-})
-
-/*
-Some comment
-*/
-//Baz
-it('bar', ()=>{
-
-})
+// Nesting
+describe('other bar', () => {
+  const thing = 123;
+  test('is another bar w/ test', () => {
+  });
+  // With a comment
+  it('is another bar w/ it', () => {
+  });
+  test.skip('skipping', () => {}); // Another comment
+  it.skip('skipping too', () => {});
+});test('weird', () => {});
+test
+  .skip('skippy skip', () => {});
 `;
 
-const ruleTester = new RuleTester();
 ruleTester.run('padding-between-test-blocks', rule, {
-  valid: [validIts, validTests, validPaddedWithComments],
+  valid: [valid],
   invalid: [
     {
-      code: invalidIts,
-      output: validIts,
-      errors: [
-        {
-          message: 'Expected blank line before this statement.',
-        },
-        {
-          message: 'Expected blank line before this statement.',
-        },
-      ],
+      code: invalid,
+      errors: 10,
+      output: valid,
     },
     {
-      code: invalidTests,
-      output: validTests,
+      code: invalid,
       errors: [
         {
-          message: 'Expected blank line before this statement.'
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
+        },
+        {
+          message: 'Expected blank line before this statement.',
         },
       ],
     },

--- a/tests/lib/rules/padding-before-test-blocks.spec.js
+++ b/tests/lib/rules/padding-before-test-blocks.spec.js
@@ -97,33 +97,53 @@ ruleTester.run('padding-between-test-blocks', rule, {
       errors: [
         {
           message: 'Expected blank line before this statement.',
+          line: 4,
+          column: 1
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 7,
+          column: 1
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 10,
+          column: 1
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 11,
+          column: 1
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 16,
+          column: 3
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 19,
+          column: 3
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 21,
+          column: 3
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 22,
+          column: 3
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 23,
+          column: 4
         },
         {
           message: 'Expected blank line before this statement.',
+          line: 24,
+          column: 1
         },
       ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1151,10 +1151,8 @@ eslint-plugin-import@2.14.0:
     read-pkg-up "^2.0.0"
     resolve "^1.6.0"
 
-eslint-plugin-jest-formatting@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest-formatting/-/eslint-plugin-jest-formatting-0.0.10.tgz#290062db975f80c087af0524da3bf5e65d50dcaa"
-  integrity sha512-6fJrittgd/Wj9T+dKrJnwA2DK8FZF8H13X71Wpi+txotdXIRfcRZwX5DJsypENm5DN6A8DzyOaYnQlFj+klK0A==
+"eslint-plugin-jest-formatting@file:./.":
+  version "0.0.12"
 
 eslint-plugin-jest@22.7.0:
   version "22.7.0"


### PR DESCRIPTION
The code in `rules/padding.ts` is based on the ESLint rule
line-padding-before-statement. It's been altered to look for Jest
tokens.

Because the original padding rule was so flexible it let's us
implement this package's existing rules by passing some configuration
into `padding.ts`.

For this proof of concept...
1. Created `src/rules/padding.ts`
2. Re-implemented `src/rules/padding-before-test-blocks.ts` w/ `padding.ts`
3. Re-implemented `src/rules/padding-before-describe-blocks.ts` w/ `padding.ts`
4. Expanded the test data in `padding-before-describe-blocks` test
5. Minor change to tests in `padding-before-test-blocks` test (see comment below)

Additional changes
- Pointed package.json dependency for this package to itself

TODO
- [ ] Inspect filepath (or use some other means) to determine that we are in a Jest file.
- [ ] Implement remaining rules
  - [ ] afterAll
  - [ ] afterEach
  - [ ] beforeAll
  - [ ] beforeEach
  - [x] expect
- [x] Write tests for (and see if it works with) describe.each, test.skip,
  describe.skip, etc. (It should just work)
- [x] Try some multiline stuff... `describe{NEWLINE}.skip` or
  `expect(val){NEWLINE}.toEqual()` and otherwise just generally get
  weird with it.
- [ ] Check how this works if used alongside `padding-line-before-statement`



Issue 41