### PR TITLE
Fix examples for padding-before-test-blocks rule

### DIFF
--- a/docs/rules/padding-before-test-blocks.md
+++ b/docs/rules/padding-before-test-blocks.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule enforces at least one line of padding before test blocks with a describe (newling or comment).
+This rule enforces at least one line of padding before test blocks with a describe (newline or comment).
 
 Examples of **incorrect** code for this rule:
 
@@ -20,14 +20,6 @@ describe('foo', () => {
 });
 ```
 
-```js
-describe('foo', () => {
-  it('foo', () => {});
-
-  it('bar', () => {});
-});
-```
-
 Examples of **correct** code for this rule:
 
 ```js
@@ -35,14 +27,6 @@ describe('foo', () => {
   test('foo', () => {});
 
   test('bar', () => {});
-});
-```
-
-```js
-describe('foo', () => {
-  it('foo', () => {});
-
-  it('bar', () => {});
 });
 ```
 


### PR DESCRIPTION
The same code example appears as incorrect code and twice as correct code for the padding-before-test-blocks rule.

Removed the extraneous code examples.

Also, fixed a typo in the text.