### PR TITLE
Bump to v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## v0.1.0 - July 20, 2019
+
+### Rules Added
+
+- padding-before-all
+
+- padding-before-after-all-blocks
+
+- padding-before-after-each-blocks
+
+- padding-before-before-all-blocks
+
+- padding-before-before-each-blocks
+
+- padding-before-expect-statements
+
+### Other
+
+- Security update of lodash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jest-formatting",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "description": "Formatting rules for jest tests",
   "keywords": [
     "eslint",


### PR DESCRIPTION
This release v0.1.0

New rules:

- padding-before-all
- padding-before-after-all-blocks
- padding-before-after-each-blocks
- padding-before-before-all-blocks
- padding-before-before-each-blocks
- padding-before-expect-statements

