### PR TITLE
Add a rule to enforce padding around expect groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ _or_
 
 ## Rule Documentation
 
+- [padding-around-expect-statements](docs/rules/padding-around-expect-statements.md)
+
 - [padding-before-all](docs/rules/padding-before-all.md)
 
 - [padding-before-after-all-blocks](docs/rules/padding-before-after-all-blocks.md)
@@ -63,5 +65,8 @@ _or_
 - [padding-before-before-all-blocks](docs/rules/padding-before-before-all-blocks.md)
 - [padding-before-before-each-blocks](docs/rules/padding-before-before-each-blocks.md)
 - [padding-before-describe-blocks](docs/rules/padding-before-describe-blocks.md)
-- [padding-before-expect-statements](docs/rules/padding-before-expect-statements.md)
 - [padding-before-test-blocks](docs/rules/padding-before-test-blocks.md)
+
+### Deprecated
+
+- [padding-around-expect-statements](docs/rules/padding-before-expect-statements.md)

--- a/docs/rules/padding-around-expect-statements.md
+++ b/docs/rules/padding-around-expect-statements.md
@@ -1,0 +1,34 @@
+# padding-around-expect-statements
+
+## Rule Details
+
+This rule enforces a line of padding before _and_ after 1 or more `expect` statements
+
+Note that it does _not_ enforce a line of padding between an `expect` and a closing bracket in a block statement
+
+Examples of **incorrect** code for this rule:
+
+```js
+test('thing one', () => {
+  let abc = 123;
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc);
+  abc = 456;
+  expect(abc).toEqual(456);
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+test('thing one', () => {
+  let abc = 123;
+
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc);
+
+  abc = 456;
+
+  expect(abc).toEqual(456);
+});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,11 @@ export const rules = {
     { blankLine: 'always', prev: '*', next: 'expect' },
     { blankLine: 'any', prev: 'expect', next: 'expect' },
   ]),
+  'padding-around-expect-groups': makeRule([
+    { blankLine: 'always', prev: '*', next: 'expect' },
+    { blankLine: 'always', prev: 'expect', next: '*' },
+    { blankLine: 'any', prev: 'expect', next: 'expect' },
+  ]),
   'padding-before-test-blocks': makeRule([
     { blankLine: 'always', prev: '*', next: ['test', 'it'] },
   ]),

--- a/tests/lib/rules/padding-around-expect-groups.spec.js
+++ b/tests/lib/rules/padding-around-expect-groups.spec.js
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview Enforces single line padding around groups of expect statements
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib').rules['padding-around-expect-groups'];
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const valid = `
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  let abc = 123;
+
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+
+  abc = 456;
+
+  expect(abc).toEqual(456);
+});
+
+test('thing one', () => {
+  const abc = 123;
+
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+`;
+
+const invalid = `
+foo();
+bar();
+
+const someText = 'abc';
+const someObject = {
+  one: 1,
+  two: 2,
+};
+
+test('thing one', () => {
+  let abc = 123;
+  expect(abc).toEqual(123);
+  expect(123).toEqual(abc); // Line comment
+  abc = 456;
+  expect(abc).toEqual(456);
+});
+
+test('thing one', () => {
+  const abc = 123;
+  expect(abc).toEqual(123);
+
+  const xyz = 987;
+  expect(123).toEqual(abc); // Line comment
+});
+
+describe('someText', () => {
+  describe('some condition', () => {
+    test('foo', () => {
+      const xyz = 987;
+      // Comment
+      expect(xyz).toEqual(987);
+      expect(1)
+        .toEqual(1);
+      expect(true).toEqual(true);
+    });
+  });
+});
+`;
+
+ruleTester.run('padding-around-expect-groups', rule, {
+  valid: [
+    valid,
+    {
+      code: invalid,
+      filename: 'src/component.jsx',
+    }
+  ],
+  invalid: [
+    {
+      code: invalid,
+      filename: 'src/component.test.jsx',
+      errors: 6,
+      output: valid,
+    },
+    {
+      code: invalid,
+      filename: 'src/component.test.js',
+      errors: [
+        {
+          message: 'Expected blank line before this statement.',
+          line: 13,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 15,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 16,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 21,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 24,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 32,
+          column: 7
+        },
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
Added rule: `padding-around-expect-groups`

As identified in issue #51, Adding padding before expect statements does not take into consideration that there should also be a line of padding following groups of expect statements as well.

before:

```js
test('thing one', () => {
  let abc = 123;

  expect(abc).toEqual(123);
  expect(123).toEqual(abc); // Line comment
  abc = 456;

  expect(abc).toEqual(456);
});
```

after:

```js
test('thing one', () => {
  let abc = 123;

  expect(abc).toEqual(123);
  expect(123).toEqual(abc); // Line comment

  abc = 456;

  expect(abc).toEqual(456);
});
```