### PR TITLE
Add  `padding-around-after-all-blocks` rule to supersede `padding-before-after-all-blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ _or_
 
 ## Rule Documentation
 
+- [padding-around-after-all-blocks](docs/rules/padding-around-after-all-blocks.md)
 - [padding-around-after-each-statements](docs/rules/padding-around-after-each-statements.md)
 - [padding-around-before-all-blocks](docs/rules/padding-around-before-all-blocks.md)
 - [padding-around-before-each-blocks](docs/rules/padding-around-before-each-blocks.md)

--- a/docs/rules/padding-around-after-all-blocks.md
+++ b/docs/rules/padding-around-after-all-blocks.md
@@ -1,0 +1,25 @@
+# padding-around-after-all-blocks
+
+## Rule Details
+
+This rule enforces a line of padding before _and_ after 1 or more `afterAll` statements.
+
+Note that it doesn't add/enforce a padding line if it's the last statement in its scope.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const someText = 'abc';
+afterAll(() => {});
+describe('someText', () => {});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const someText = 'abc';
+
+afterAll(() => {});
+
+describe('someText', () => {});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import { makeRule } from './utils';
 //------------------------------------------------------------------------------
 
 export const rules = {
+  'padding-around-after-all-blocks': makeRule([
+    { blankLine: 'always', prev: '*', next: 'afterAll' },
+    { blankLine: 'always', prev: 'afterAll', next: '*' },
+  ]),
   'padding-around-after-each-blocks': makeRule([
     { blankLine: 'always', prev: '*', next: 'afterEach' },
     { blankLine: 'always', prev: 'afterEach', next: '*' },

--- a/tests/lib/rules/padding-around-after-all-blocks.spec.js
+++ b/tests/lib/rules/padding-around-after-all-blocks.spec.js
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Enforces single line padding before afterAll blocks
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib').rules['padding-around-after-all-blocks'];
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const invalid = `
+const someText = 'abc';
+afterAll(() => {
+});
+describe('someText', () => {
+  const something = 'abc';
+  // A comment
+  afterAll(() => {
+    // stuff
+  });
+  afterAll(() => {
+    // other stuff
+  });
+});
+
+describe('someText', () => {
+  const something = 'abc';
+  afterAll(() => {
+    // stuff
+  });
+});
+`;
+
+const valid = `
+const someText = 'abc';
+
+afterAll(() => {
+});
+
+describe('someText', () => {
+  const something = 'abc';
+
+  // A comment
+  afterAll(() => {
+    // stuff
+  });
+
+  afterAll(() => {
+    // other stuff
+  });
+});
+
+describe('someText', () => {
+  const something = 'abc';
+
+  afterAll(() => {
+    // stuff
+  });
+});
+`;
+
+ruleTester.run('padding-before-after-all-blocks', rule, {
+  valid: [
+    valid,
+    {
+      code: invalid,
+      filename: 'src/component.jsx'
+    }
+  ],
+  invalid: [
+    {
+      code: invalid,
+      filename: 'src/component.test.jsx',
+      errors: 5,
+      output: valid,
+    },
+    {
+      code: invalid,
+      filename: 'src/component.test.js',
+      errors: [
+        {
+          message: 'Expected blank line before this statement.',
+          line: 3,
+          column: 1
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 5,
+          column: 1
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 8,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 11,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 18,
+          column: 3
+        },
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
This adds a `padding-around-after-all-blocks` rule


```js
const someText = 'abc';
afterAll(() => {
});
describe('someText', () => {});
```

becomes

```js
const someText = 'abc';
// padding before
afterAll(() => {
});
// padding after
describe('someText', () => {});
```

