### PR TITLE
Add `padding-around-after-each-blocks` rule to supersede `padding-before-after-each-blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ _or_
 
 ## Rule Documentation
 
+- [padding-around-after-each-statements](docs/rules/padding-around-after-each-statements.md)
 - [padding-around-before-all-blocks](docs/rules/padding-around-before-all-blocks.md)
 - [padding-around-before-each-blocks](docs/rules/padding-around-before-each-blocks.md)
 - [padding-around-expect-statements](docs/rules/padding-around-expect-statements.md)

--- a/docs/rules/padding-around-after-each-blocks.md
+++ b/docs/rules/padding-around-after-each-blocks.md
@@ -1,0 +1,29 @@
+# padding-around-after-each-blocks
+
+## Rule Details
+
+This rule enforces a line of padding before _and_ after 1 or more `afterEach` statements.
+
+Note that it doesn't add/enforce a padding line if it's the last statement in its scope.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const something = 123;
+afterEach(() => {
+  // more stuff
+});
+describe('foo', () => {});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const something = 123;
+
+afterEach(() => {
+  // more stuff
+});
+
+describe('foo', () => {});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import { makeRule } from './utils';
 //------------------------------------------------------------------------------
 
 export const rules = {
+  'padding-around-after-each-blocks': makeRule([
+    { blankLine: 'always', prev: '*', next: 'afterEach' },
+    { blankLine: 'always', prev: 'afterEach', next: '*' },
+  ]),
   'padding-around-before-all-blocks': makeRule([
     { blankLine: 'always', prev: '*', next: 'beforeAll' },
     { blankLine: 'always', prev: 'beforeAll', next: '*' },

--- a/tests/lib/rules/padding-around-after-each-blocks.spec.js
+++ b/tests/lib/rules/padding-around-after-each-blocks.spec.js
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Enforces single line padding around afterEach blocks
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib').rules['padding-around-after-each-blocks'];
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const invalid = `
+const someText = 'abc';
+afterEach(() => {
+});
+describe('someText', () => {
+  const something = 'abc';
+  // A comment
+  afterEach(() => {
+    // stuff
+  });
+  afterEach(() => {
+    // other stuff
+  });
+});
+describe('someText', () => {
+  const something = 'abc';
+  afterEach(() => {
+    // stuff
+  });
+});
+`;
+
+const valid = `
+const someText = 'abc';
+
+afterEach(() => {
+});
+
+describe('someText', () => {
+  const something = 'abc';
+
+  // A comment
+  afterEach(() => {
+    // stuff
+  });
+
+  afterEach(() => {
+    // other stuff
+  });
+});
+describe('someText', () => {
+  const something = 'abc';
+
+  afterEach(() => {
+    // stuff
+  });
+});
+`;
+
+ruleTester.run('padding-before-after-each-blocks', rule, {
+  valid: [
+    valid,
+    {
+      code: invalid,
+      filename: 'src/component.jsx'
+    }
+  ],
+  invalid: [
+    {
+      code: invalid,
+      errors: 5,
+      filename: 'src/component.test.jsx',
+      output: valid,
+    },
+    {
+      code: invalid,
+      filename: 'src/component.test.js',
+      errors: [
+        {
+          message: 'Expected blank line before this statement.',
+          line: 3,
+          column: 1
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 5,
+          column: 1
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 8,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 11,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 17,
+          column: 3
+        },
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
Examples of **incorrect** code for this rule:

```js
const something = 123;
afterEach(() => {
  // more stuff
});
describe('foo', () => {});
```

Examples of **correct** code for this rule:

```js
const something = 123;

afterEach(() => {
  // more stuff
});

describe('foo', () => {});
```
