### PR TITLE
Add `padding-around-before-all-blocks` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ _or_
 
 ## Rule Documentation
 
+- [padding-around-before-all-blocks](docs/rules/padding-around-before-all-blocks.md)
 - [padding-around-expect-statements](docs/rules/padding-around-expect-statements.md)
 
 - [padding-before-all](docs/rules/padding-before-all.md)

--- a/docs/rules/padding-around-before-all-blocks.md
+++ b/docs/rules/padding-around-before-all-blocks.md
@@ -1,0 +1,29 @@
+# padding-around-before-all-blocks
+
+## Rule Details
+
+This rule enforces a line of padding before _and_ after `beforeAll` statements.
+
+Note that it doesn't add/enforce a padding line if it's the last statement in its scope.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const something = 123;
+beforeAll(() => {
+  // more stuff
+});
+describe('foo', () => {});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const something = 123;
+
+beforeAll(() => {
+  // more stuff
+});
+
+describe('foo', () => {});
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,10 @@ import { makeRule } from './utils';
 //------------------------------------------------------------------------------
 
 export const rules = {
+  'padding-around-before-all-blocks': makeRule([
+    { blankLine: 'always', prev: '*', next: 'beforeAll' },
+    { blankLine: 'always', prev: 'beforeAll', next: '*' },
+  ]),
   'padding-before-after-all-blocks': makeRule([
     { blankLine: 'always', prev: '*', next: 'afterAll' },
   ]),

--- a/tests/lib/rules/padding-around-before-all-blocks.spec.js
+++ b/tests/lib/rules/padding-around-before-all-blocks.spec.js
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Enforces single line padding around beforeAll blocks
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const { RuleTester } = require('eslint');
+const rule = require('../../../lib').rules['padding-around-before-all-blocks'];
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const invalid = `
+const someText = 'abc';
+beforeAll(() => {
+});
+describe('someText', () => {
+  const something = 'abc';
+  // A comment
+  beforeAll(() => {
+    // stuff
+  });
+  beforeAll(() => {
+    // other stuff
+  });
+});
+
+describe('someText', () => {
+  const something = 'abc';
+  beforeAll(() => {
+    // stuff
+  });
+});
+`;
+
+const valid = `
+const someText = 'abc';
+
+beforeAll(() => {
+});
+
+describe('someText', () => {
+  const something = 'abc';
+
+  // A comment
+  beforeAll(() => {
+    // stuff
+  });
+
+  beforeAll(() => {
+    // other stuff
+  });
+});
+
+describe('someText', () => {
+  const something = 'abc';
+
+  beforeAll(() => {
+    // stuff
+  });
+});
+`;
+
+ruleTester.run('padding-before-before-all-blocks', rule, {
+  valid: [
+    valid,
+    {
+      code: invalid,
+      filename: 'src/component.jsx'
+    }
+  ],
+  invalid: [
+    {
+      code: invalid,
+      filename: 'src/component.test.jsx',
+      errors: 5,
+      output: valid,
+    },
+    {
+      code: invalid,
+      filename: 'src/component.test.js',
+      errors: [
+        {
+          message: 'Expected blank line before this statement.',
+          line: 3,
+          column: 1
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 5,
+          column: 1
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 8,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 11,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 18,
+          column: 3
+        },
+      ]
+    },
+  ]
+});


### PR DESCRIPTION
This adds a `padding-around-before-all-blocks` to supersede `padding-before-before-all-blocks`

Examples of **incorrect** code for this rule:

```js
const something = 123;
beforeAll(() => {
  // more stuff
});
describe('foo', () => {});
```

Examples of **correct** code for this rule:

```js
const something = 123;

beforeAll(() => {
  // more stuff
});

describe('foo', () => {});
```