### PR TITLE
Export recommended config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,14 +4,14 @@
     "sourceType": "module"
   },
   "plugins": ["jest-formatting", "jest"],
-  "rules": {
-    "jest-formatting/padding-before-test-blocks": 2,
-    "jest-formatting/padding-before-describe-blocks": 2
-  },
   "env": {
     "jest/globals": true
   },
-  "extends": ["airbnb-base", "plugin:prettier/recommended"],
+  "extends": [
+    "airbnb-base",
+    "plugin:prettier/recommended",
+    "plugin:jest-formatting/recommended"
+  ],
   "overrides": [
     {
       "files": ["**.*"],

--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ Then configure the rules you want to use under the rules section.
 ```json
 {
   "rules": {
-    "jest-formatting/padding-before-all": 2
+    "jest-formatting/padding-around-describe-blocks": 2,
+    "jest-formatting/padding-around-test-blocks": 2
   }
 }
 ```
 
 _or_
 
+You can use our recommeneded settings which enables all of the rules for you
+
 ```json
 {
-  "rules": {
-    "jest-formatting/padding-around-describe-blocks": 2,
-    "jest-formatting/padding-around-test-blocks": 2
-  }
+  "extends": ["plugin:jest-formatting/recommended"]
 }
 ```
 
@@ -64,10 +64,9 @@ _or_
 - [padding-around-describe-blocks](docs/rules/padding-around-describe-blocks.md)
 - [padding-around-test-blocks](docs/rules/padding-around-test-blocks.md)
 
-- [padding-before-all](docs/rules/padding-before-all.md)
-
 ### Deprecated
 
+- [padding-before-all](docs/rules/padding-before-all.md)
 - [padding-before-before-each-blocks](docs/rules/padding-before-before-each-blocks.md)
 - [padding-before-after-each-blocks](docs/rules/padding-before-after-each-blocks.md)
 - [padding-before-before-all-blocks](docs/rules/padding-before-before-all-blocks.md)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "eslintplugin",
     "eslint-plugin",
     "jest",
-    "format"
+    "format",
+    "formatting",
+    "padding"
   ],
   "author": "Dan Green-Leipciger",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,3 +80,18 @@ export const rules = {
     { blankLine: 'any', prev: 'expect', next: 'expect' },
   ]),
 };
+
+export const configs = {
+  recommended: {
+    plugins: ['jest-formatting'],
+    rules: {
+      'jest-formatting/padding-around-after-all-blocks': 2,
+      'jest-formatting/padding-around-after-each-blocks': 2,
+      'jest-formatting/padding-around-before-all-blocks': 2,
+      'jest-formatting/padding-around-before-each-blocks': 2,
+      'jest-formatting/padding-around-expect-groups': 2,
+      'jest-formatting/padding-around-describe-blocks': 2,
+      'jest-formatting/padding-around-test-blocks': 2,
+    },
+  },
+};

--- a/tests/dogfood.spec.js
+++ b/tests/dogfood.spec.js
@@ -1,15 +1,32 @@
+//  'afterAll',
+
+beforeAll(() => {});
+
+beforeEach(() => {});
+
+afterAll(() => {});
+
+afterEach(() => {});
+
 describe('no padding on top', () => {
   it('has no padding above', () => {
     expect(true);
   });
 
+  expect(true);
+  expect(1);
+
   it('has padding above', () => {
+    expect(true);
+  });
+
+  it('also has padding above but not below', () => {
     expect(true);
   });
 });
 
 describe('padding above', () => {
-  it('has no padding above', () => {
+  it('has no padding above or below', () => {
     expect(true);
   });
 });

--- a/tests/dogfood.spec.js
+++ b/tests/dogfood.spec.js
@@ -1,5 +1,3 @@
-//  'afterAll',
-
 beforeAll(() => {});
 
 beforeEach(() => {});


### PR DESCRIPTION
This exports a recommended config which enables all the rules by default. 

This marks the `before-all` rule as deprecated.

Note: I am still +1 to having a rule that turns on all of the rules on top of this 'extends recommened'