### PR TITLE
Update the CHANGELOG to include what's happened for `1.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,32 @@
 # Changelog
 
+## v1.0.0 - August 12, 2019
+
+### Added
+
+- Introduction of a "recommend" rules section
+
+- Improve documentation
+
+### Deprecated
+
+- The `padding-before-all` rule has been deprecated
+
 ## v0.1.0 - July 20, 2019
 
 ### Rules Added
 
-- padding-before-all
+- `padding-before-all`
 
-- padding-before-after-all-blocks
+- `padding-before-after-all-blocks`
 
-- padding-before-after-each-blocks
+- `padding-before-after-each-blocks`
 
-- padding-before-before-all-blocks
+- `padding-before-before-all-blocks`
 
-- padding-before-before-each-blocks
+- `padding-before-before-each-blocks`
 
-- padding-before-expect-statements
+- `padding-before-expect-statements`
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Introduction of a "recommend" rules section
+- Exposes "recommended" rules for eslint `extends`
 
 - Improve documentation
 


### PR DESCRIPTION
We created version `1.0.0` in 35912544b3d7122b803ffaabf6f772984473af87,
but didn't update the changelog as we did this.

This commit tries to summarize what has happened between `0.1.0` and
`1.0.0`. A full list of commits between these two points can be found
here:
https://github.com/dangreenisrael/eslint-plugin-jest-formatting/compare/v0.1.0...v1.0.0