### PR TITLE
Remove `padding-around-expect-groups` rule from the "recommended" setting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v1.1.0 - August 14, 2019
+
+### Changed
+
+- Removed `padding-around-expect-groups` from the "recommended" set of rules.
+
+### Added
+
+- Exposes "strict" rules for eslint `extends`. This preset is equivalent to version `1.0.0`'s "recommended" preset.
+
 ## v1.0.0 - August 12, 2019
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,11 +48,19 @@ Then configure the rules you want to use under the rules section.
 
 _or_
 
-You can use our recommeneded settings which enables all of the rules for you
+You can use our "recommended" settings which enables most of the rules for you
 
 ```json
 {
   "extends": ["plugin:jest-formatting/recommended"]
+}
+```
+
+We also support a "strict" settings which enabled all of the rules for you
+
+```json
+{
+  "extends": ["plugin:jest-formatting/strict"]
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jest-formatting",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Formatting rules for jest tests",
   "keywords": [
     "eslint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,6 +89,17 @@ export const configs = {
       'jest-formatting/padding-around-after-each-blocks': 2,
       'jest-formatting/padding-around-before-all-blocks': 2,
       'jest-formatting/padding-around-before-each-blocks': 2,
+      'jest-formatting/padding-around-describe-blocks': 2,
+      'jest-formatting/padding-around-test-blocks': 2,
+    },
+  },
+  strict: {
+    plugins: ['jest-formatting'],
+    rules: {
+      'jest-formatting/padding-around-after-all-blocks': 2,
+      'jest-formatting/padding-around-after-each-blocks': 2,
+      'jest-formatting/padding-around-before-all-blocks': 2,
+      'jest-formatting/padding-around-before-each-blocks': 2,
       'jest-formatting/padding-around-expect-groups': 2,
       'jest-formatting/padding-around-describe-blocks': 2,
       'jest-formatting/padding-around-test-blocks': 2,


### PR DESCRIPTION
Based on the discussion in https://github.com/dangreenisrael/eslint-plugin-jest-formatting/issues/66

This commit removes the `padding-around-expect-groups` rule from the
"recommended" rules. This commit also introduces a "strict" setting for
users who would still like to make use of this (super cool) lint rule.

This commit also updates the version of the package to `1.1.0`.

Closes #66 