### PR TITLE
Chore/linting updates

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,7 +17,8 @@
     {
       "files": ["**.*"],
       "rules": {
-        "camelcase": "off"
+        "camelcase": "off",
+        "no-plusplus": "off",
       }
     }
   ]

--- a/.eslintrc
+++ b/.eslintrc
@@ -3,12 +3,13 @@
   "parserOptions": {
     "sourceType": "module"
   },
-  "plugins": ["jest-formatting", "jest"],
+  "plugins": ["jest-formatting", "jest", "@typescript-eslint/eslint-plugin"],
   "env": {
     "jest/globals": true
   },
   "extends": [
     "airbnb-base",
+    "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
     "plugin:jest-formatting/recommended"
   ],

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,7 +11,8 @@
     "airbnb-base",
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
-    "plugin:jest-formatting/recommended"
+    "plugin:jest-formatting/recommended",
+    "plugin:import/typescript"
   ],
   "overrides": [
     {
@@ -19,7 +20,15 @@
       "rules": {
         "camelcase": "off",
         "no-plusplus": "off",
+        "import/extensions": "off"
       }
     }
-  ]
+  ],
+  "settings": {
+    "import/resolver": {
+      "typescript": {
+        "alwaysTryTypes": true // Without this `@types/estree` `estree` isn't actually in our node_modules.
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^7.3.1",
     "eslint-config-airbnb-base": "^14.2.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-plugin-import": "^2.21.2",
     "eslint-plugin-jest": "^23.17.1",
     "eslint-plugin-jest-formatting": "file:.",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "module": "src/index.ts",
   "scripts": {
     "pretty": "yarn prettier '**/*.*'",
-    "lint": "yarn build && yarn link-plugin && yarn pretty --check && yarn eslint . --ext .ts",
-    "format": "yarn build && yarn link-plugin && yarn pretty --write && yarn eslint --fix . --ext .ts",
+    "lint": "yarn build && yarn link-plugin && yarn pretty --check && yarn eslint --ext .ts,.js .",
+    "format": "yarn build && yarn link-plugin && yarn pretty --write && yarn eslint --fix --ext .ts,.js .",
     "build": "tsc",
     "test": "yarn build && jest",
     "link-plugin": "yarn link && yarn link eslint-plugin-jest-formatting"

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "module": "src/index.ts",
   "scripts": {
     "pretty": "yarn prettier '**/*.*'",
-    "lint": "yarn build && yarn link-plugin && yarn pretty --check && yarn eslint .",
-    "format": "yarn build && yarn link-plugin && yarn pretty --write && yarn eslint --fix .",
+    "lint": "yarn build && yarn link-plugin && yarn pretty --check && yarn eslint . --ext .ts",
+    "format": "yarn build && yarn link-plugin && yarn pretty --write && yarn eslint --fix . --ext .ts",
     "build": "tsc",
     "test": "yarn build && jest",
     "link-plugin": "yarn link && yarn link eslint-plugin-jest-formatting"
@@ -33,6 +33,7 @@
     "@types/eslint": "^7.2.0",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.13",
+    "@typescript-eslint/eslint-plugin": "^3.4.0",
     "@typescript-eslint/parser": "^3.4.0",
     "eslint": "^7.3.1",
     "eslint-config-airbnb-base": "^14.2.0",

--- a/src/ast-utils.ts
+++ b/src/ast-utils.ts
@@ -1,4 +1,6 @@
 import { AST, SourceCode } from 'eslint';
+// This is because we are using @types/estree that are brought in with eslint
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { Node } from 'estree';
 
 export const isTokenASemicolon = (token: AST.Token): boolean =>

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -271,8 +271,8 @@ const verifyNode = (node: Node, paddingContext: PaddingContext): void => {
   //  ESTree.Node doesn't support the parent property which is added by
   //  ESLint during traversal. Our best bet is to ignore the property access
   //  here as it's the only place that it's checked.
-  // @ts-ignore
-  if (!astUtils.isValidParent(node.parent.type)) {
+  //  eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (!astUtils.isValidParent((node as any).parent.type)) {
     return;
   }
 

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -9,6 +9,8 @@
  */
 
 import { AST, Rule, SourceCode } from 'eslint';
+// This is because we are using @types/estree that are brought in with eslint
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { Node } from 'estree';
 import * as astUtils from '../ast-utils';
 

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -314,7 +314,7 @@ const verifyNode = (node: Node, paddingContext: PaddingContext): void => {
  */
 export const createRule = (
   configs: Config[],
-  deprecated: boolean = false,
+  deprecated = false,
 ): Rule.RuleModule => ({
   meta: {
     fixable: 'whitespace',

--- a/tests/catfood.js
+++ b/tests/catfood.js
@@ -4,6 +4,8 @@
  * globs.
  */
 
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 beforeAll(() => {});
 beforeEach(() => {});
 afterAll(() => {});

--- a/tests/dogfood.spec.js
+++ b/tests/dogfood.spec.js
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+
 beforeAll(() => {});
 
 beforeEach(() => {});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1455,6 +1455,17 @@ eslint-import-resolver-node@^0.3.3:
     debug "^2.6.9"
     resolve "^1.13.1"
 
+eslint-import-resolver-typescript@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.0.0.tgz#e95f126cc12d3018b9cc11692b4dbfd3e17d3ea6"
+  integrity sha512-bT5Frpl8UWoHBtY25vKUOMoVIMlJQOMefHLyQ4Tz3MQpIZ2N6yYKEEIHMo38bszBNUuMBW6M3+5JNYxeiGFH4w==
+  dependencies:
+    debug "^4.1.1"
+    is-glob "^4.0.1"
+    resolve "^1.12.0"
+    tiny-glob "^0.2.6"
+    tsconfig-paths "^3.9.0"
+
 eslint-module-utils@^2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz#579ebd094f56af7797d19c9866c9c9486629bfa6"
@@ -1913,6 +1924,16 @@ globals@^12.1.0:
   integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
   dependencies:
     type-fest "^0.8.1"
+
+globalyzer@^0.1.0:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/globalyzer/-/globalyzer-0.1.4.tgz#bc8e273afe1ac7c24eea8def5b802340c5cc534f"
+  integrity sha512-LeguVWaxgHN0MNbWC6YljNMzHkrCny9fzjmEUdnF1kQ7wATFD1RHFRqA1qxaX2tgxGENlcxjOflopBwj3YZiXA==
+
+globrex@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/globrex/-/globrex-0.1.2.tgz#dd5d9ec826232730cd6793a5e33a9302985e6098"
+  integrity sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==
 
 graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   version "4.2.4"
@@ -3599,7 +3620,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2:
+resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
@@ -4061,6 +4082,14 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+tiny-glob@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tiny-glob/-/tiny-glob-0.2.6.tgz#9e056e169d9788fe8a734dfa1ff02e9b92ed7eda"
+  integrity sha512-A7ewMqPu1B5PWwC3m7KVgAu96Ch5LA0w4SnEN/LbDREj/gAD0nPWboRbn8YoP9ISZXqeNAlMvKSKoEuhcfK3Pw==
+  dependencies:
+    globalyzer "^0.1.0"
+    globrex "^0.1.1"
 
 tmpl@1.0.x:
   version "1.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -615,6 +615,18 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@typescript-eslint/eslint-plugin@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.4.0.tgz#8378062e6be8a1d049259bdbcf27ce5dfbeee62b"
+  integrity sha512-wfkpiqaEVhZIuQRmudDszc01jC/YR7gMSxa6ulhggAe/Hs0KVIuo9wzvFiDbG3JD5pRFQoqnf4m7REDsUvBnMQ==
+  dependencies:
+    "@typescript-eslint/experimental-utils" "3.4.0"
+    debug "^4.1.1"
+    functional-red-black-tree "^1.0.1"
+    regexpp "^3.0.0"
+    semver "^7.3.2"
+    tsutils "^3.17.1"
+
 "@typescript-eslint/experimental-utils@3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-3.4.0.tgz#8a44dfc6fb7f1d071937b390fe27608ebda122b8"
@@ -3493,7 +3505,7 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexpp@^3.1.0:
+regexpp@^3.0.0, regexpp@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.1.0.tgz#206d0ad0a5648cffbdb8ae46438f3dc51c9f78e2"
   integrity sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==


### PR DESCRIPTION
Turns out we weren't running eslint on ts files 🤦.

This adds `ts` as an extension and fixes all the errors that came up.