### PR TITLE
Allow `await`ed `expect`s to be next to regular ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.0.0 - May 4, 2021
+
+### Breaking Changes
+
+- Padding is no longer enforced between statements and `await`ed statements of the same kind.
+
 ## v1.1.0 - August 14, 2019
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-jest-formatting",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "ESLint rules for formatting jest tests",
   "keywords": [
     "eslint",

--- a/src/rules/padding.ts
+++ b/src/rules/padding.ts
@@ -79,13 +79,20 @@ interface PaddingContext {
 // Creates a StatementTester to test an ExpressionStatement's first token name
 const createTokenTester = (tokenName: string): StatementTester => {
   return (node: Node, sourceCode: SourceCode): boolean => {
-    const token = sourceCode.getFirstToken(node);
+    let activeNode = node;
 
-    return (
-      node.type === 'ExpressionStatement' &&
-      token.type === 'Identifier' &&
-      token.value === tokenName
-    );
+    if (activeNode.type === 'ExpressionStatement') {
+      // In the case of `await`, we actually care about its argument
+      if (activeNode.expression.type === 'AwaitExpression') {
+        activeNode = activeNode.expression.argument;
+      }
+
+      const token = sourceCode.getFirstToken(activeNode);
+
+      return token.type === 'Identifier' && token.value === tokenName;
+    }
+
+    return false;
   };
 };
 

--- a/tests/lib/rules/padding-around-expect-groups.spec.js
+++ b/tests/lib/rules/padding-around-expect-groups.spec.js
@@ -11,7 +11,7 @@ const rule = require('../../../lib').rules['padding-around-expect-groups'];
 
 const ruleTester = new RuleTester({
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 2017,
   },
 });
 
@@ -63,6 +63,29 @@ describe('someText', () => {
     });
   });
 });
+
+test('awaited expect', async () => {
+  const abc = 123;
+  const hasAPromise = () => Promise.resolve('foo');
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  expect(abc).toEqual(123);
+
+  const efg = 456;
+
+  expect(123).toEqual(abc);
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const hij = 789;
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const somethingElseAsync = () => Promise.resolve('bar');
+  await somethingElseAsync();
+
+  await expect(hasAPromise()).resolves.toEqual('foo');
+});
 `;
 
 const invalid = `
@@ -103,6 +126,25 @@ describe('someText', () => {
     });
   });
 });
+
+test('awaited expect', async () => {
+  const abc = 123;
+  const hasAPromise = () => Promise.resolve('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  expect(abc).toEqual(123);
+
+  const efg = 456;
+  expect(123).toEqual(abc);
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const hij = 789;
+  await expect(hasAPromise()).resolves.toEqual('foo');
+  await expect(hasAPromise()).resolves.toEqual('foo');
+
+  const somethingElseAsync = () => Promise.resolve('bar');
+  await somethingElseAsync();
+  await expect(hasAPromise()).resolves.toEqual('foo');
+});
 `;
 
 ruleTester.run('padding-around-expect-groups', rule, {
@@ -111,7 +153,7 @@ ruleTester.run('padding-around-expect-groups', rule, {
     {
       code: invalid,
       filename: 'src/component.test.jsx',
-      errors: 6,
+      errors: 10,
       output: valid,
     },
     {
@@ -147,6 +189,26 @@ ruleTester.run('padding-around-expect-groups', rule, {
           message: 'Expected blank line before this statement.',
           line: 32,
           column: 7
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 43,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 47,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 51,
+          column: 3
+        },
+        {
+          message: 'Expected blank line before this statement.',
+          line: 56,
+          column: 3
         },
       ],
       output: valid,


### PR DESCRIPTION
Full disclosure: This is my first foray into the world of ESTrees, so this solution comes largely from a place of "well, I found a way to do it that works" and less one of "I know what I need to do and I did it."

So that said, if there is a completely different approach that you had in mind when first reading the issue I filed, then I'd be happy to re-approach this, or hand it off; whatever you prefer.

Fixes #98.