### PR TITLE
chore(readme): remove `$` to make commands copy-pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Like this plugin? [Say thanks with a ⭐️](https://github.com/dangreenisrael/e
 You'll first need to install [ESLint](http://eslint.org):
 
 ```
-$ yarn add eslint --dev
+yarn add eslint --dev
 ```
 
 Next, install `eslint-plugin-jest-formatting`:
 
 ```
-$ yarn add eslint-plugin-jest-formatting --dev
+yarn add eslint-plugin-jest-formatting --dev
 ```
 
 **Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-jest-formatting` globally.


### PR DESCRIPTION
Thanks for the plugin!

Just an idea: GitHub add copy button to all code blocks in MD files. I just used that button to copy Yarn command and hit: "command not found: $". Removing the `$` fro both commands makes them more copy-pasteable.

I understand that same Readme.md will be visible on NPM and that NPM does not have similar button. User has to select the command manually. Still someone could select the `$` and get the same error.

This is just a detail. Feel free to close (;