### PR TITLE
DOCS: fix "describe" rule name typo

### DIFF
--- a/docs/rules/padding-around-describe-blocks.md
+++ b/docs/rules/padding-around-describe-blocks.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This rule enforces a line of padding before _and_ after 1 or more `beforeEach` statements
+This rule enforces a line of padding before _and_ after 1 or more `describe` statements
 
 Note that it doesn't add/enforce a padding line if it's the last statement in its scope
 


### PR DESCRIPTION
The rule details incorrectly refers to the `beforeEach` rule, when it should be the `describe` rule.